### PR TITLE
feat: Add requests-like API for contract responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A pytest-native framework for testing NEAR smart contracts in Python.
 
 🧠 **Smart caching** - Automatically caches compiled contracts for faster subsequent runs
 
+✨ **Requests-like Response API** - Familiar interface for handling contract responses with `.json()` method and `.text` property
+
 ## Installation
 
 ```bash
@@ -126,8 +128,24 @@ class TestCounter(NearTestCase):
 
     def test_increment(self):
         # Call contract method
-        result = self.counter_contract.call("increment", {})
-        assert int(result) == 1
+        result = self.contract.call("my_function", {"param": "value"})
+        assert result.text == "expected_result"
+        
+        # If the result is JSON, you can parse it directly
+        if result.text.startswith("{") or result.text.startswith("["):
+            data = result.json()
+            assert data["some_field"] == "expected_value"
+        
+    def test_as_alice(self):
+        # Call as another account
+        result = self.contract.call_as(self.alice, "my_function", {"param": "value"})
+        assert result.text == "expected_result"
+```
+
+### 2. Run your tests
+
+```bash
+pytest test_my_contract.py -v
 ```
 
 ## Examples
@@ -160,6 +178,22 @@ def test_increment_fresh(fresh_counter, sandbox_alice):
     # Increment again
     result = fresh_counter.call("increment").as_transaction(sandbox_alice)
     assert int(result) == 2
+```
+
+### JSON Response Example
+
+```python
+def test_json_response(self):
+    # Call a method that returns JSON data
+    response = self.contract.call("get_user_data", {"user_id": "alice"})
+    
+    # Parse the JSON response
+    data = response.json()
+    
+    # Assert on the parsed data
+    assert data["name"] == "Alice"
+    assert data["score"] == 100
+    assert "created_at" in data
 ```
 
 ## Key Concepts
@@ -260,6 +294,23 @@ cls.save_state()
 self.reset_state()
 ```
 
+This state management is what makes near-pytest tests run significantly faster than traditional approaches that need to re-deploy the contract and accounts for each test.
+
+### 7. ContractResponse
+
+Contract call responses are wrapped in a `ContractResponse` object that provides a familiar interface similar to Python's `requests` library:
+
+```python
+# Get the raw text response
+text_content = response.text
+
+# Parse JSON response
+json_data = response.json()
+
+# String representation
+str_value = str(response)  # Same as response.text
+```
+
 ## API Reference
 
 ### Modular Fixtures
@@ -339,12 +390,43 @@ This distinction allows for future expansion to other networks like testnet or m
 - `call_as(account, method_name, args=None, amount=0, gas=None)`: Call as another account
 - `view(method_name, args=None)`: Call a view method
 
+### ContractResponse
+
+A wrapper for contract call responses that provides a familiar interface for handling response data.
+
+#### Properties
+
+- `text`: Get the raw text response as a string
+- `transaction_result`: Access the underlying transaction result (if available)
+
+#### Methods
+
+- `json()`: Parse the response as JSON and return the resulting Python object
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
 ## Environment Variables
 
 You can customize the behavior of near-pytest using these environment variables:
 
 - `NEAR_PYTEST_LOG_LEVEL`: Set logging level (DEBUG, INFO, WARNING, ERROR)
 - `NEAR_SANDBOX_HOME`: Specify a custom home directory for the sandbox
+
+## Architecture
+
+near-pytest consists of several core components:
+
+- **SandboxManager**: Handles the NEAR sandbox process lifecycle
+- **NearClient**: Manages communication with the NEAR RPC interface 
+- **Account/Contract**: Simplified models for interacting with the blockchain
+- **ContractResponse**: Wraps contract call responses with a user-friendly API
+- **NearTestCase**: Base class that ties everything together for testing
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -128,24 +128,8 @@ class TestCounter(NearTestCase):
 
     def test_increment(self):
         # Call contract method
-        result = self.contract.call("my_function", {"param": "value"})
-        assert result.text == "expected_result"
-        
-        # If the result is JSON, you can parse it directly
-        if result.text.startswith("{") or result.text.startswith("["):
-            data = result.json()
-            assert data["some_field"] == "expected_value"
-        
-    def test_as_alice(self):
-        # Call as another account
-        result = self.contract.call_as(self.alice, "my_function", {"param": "value"})
-        assert result.text == "expected_result"
-```
-
-### 2. Run your tests
-
-```bash
-pytest test_my_contract.py -v
+        result = self.counter_contract.call("increment", {})
+        assert int(result.text) == 1
 ```
 
 ## Examples
@@ -293,8 +277,6 @@ sandbox.reset_state(state)
 cls.save_state()
 self.reset_state()
 ```
-
-This state management is what makes near-pytest tests run significantly faster than traditional approaches that need to re-deploy the contract and accounts for each test.
 
 ### 7. ContractResponse
 

--- a/examples/test_counter.py
+++ b/examples/test_counter.py
@@ -37,23 +37,23 @@ class TestCounter(NearTestCase):
     def test_increment(self):
         # Call contract method
         result = self.counter_contract.call("increment", {})
-        assert int(result) == 1
+        assert int(result.text) == 1
 
         # Call again to verify state persistence
         result = self.counter_contract.call("increment", {})
-        assert int(result) == 2
+        assert int(result.text) == 2
 
     def test_increment_as_alice(self):
         # Each test starts with fresh state
         result = self.counter_contract.call_as(self.alice, "increment", {})
-        assert int(result) == 1
+        assert int(result.text) == 1
 
     def test_get_count(self):
         # Call view method
         result = self.counter_contract.view("get_count", {})
-        assert int(result) == 0
+        assert int(result.text) == 0
 
         # Call increment then view again
         self.counter_contract.call("increment", {})
         result = self.counter_contract.view("get_count", {})
-        assert int(result) == 1
+        assert int(result.text) == 1

--- a/examples/test_counter_modular.py
+++ b/examples/test_counter_modular.py
@@ -58,29 +58,29 @@ def fresh_counter(sandbox, counter_wasm, localnet_temp_account):
 def test_increment_shared(shared_counter, localnet_alice_account):
     """Test incrementing the shared counter as Alice."""
     # Get initial count
-    initial_count = int(shared_counter.call("get_count").as_view())
+    initial_count = int(shared_counter.call("get_count").as_view().text)
 
     # Increment as Alice
     result = shared_counter.call("increment").as_transaction(localnet_alice_account)
 
     # Assert the result is as expected
-    assert int(result) == initial_count + 1
+    assert int(result.text) == initial_count + 1
 
     # Verify state change persisted
-    new_count = int(shared_counter.call("get_count").as_view())
+    new_count = int(shared_counter.call("get_count").as_view().text)
     assert new_count == initial_count + 1
 
 
 def test_decrement_shared(shared_counter, localnet_bob_account):
     """Test decrementing the shared counter as Bob."""
     # Get initial count (which includes changes from previous tests)
-    initial_count = int(shared_counter.call("get_count").as_view())
+    initial_count = int(shared_counter.call("get_count").as_view().text)
 
     # Decrement as Bob
     result = shared_counter.call("decrement").as_transaction(localnet_bob_account)
 
     # Assert the result is as expected
-    assert int(result) == initial_count - 1
+    assert int(result.text) == initial_count - 1
 
 
 def test_increment_fresh(fresh_counter, localnet_alice_account):
@@ -92,11 +92,11 @@ def test_increment_fresh(fresh_counter, localnet_alice_account):
     """
     # This always starts with count=0 because we use a fresh contract
     result = fresh_counter.call("increment").as_transaction(localnet_alice_account)
-    assert int(result) == 1
+    assert int(result.text) == 1
 
     # Increment again
     result = fresh_counter.call("increment").as_transaction(localnet_alice_account)
-    assert int(result) == 2
+    assert int(result.text) == 2
 
 
 def test_multiple_accounts(fresh_counter, sandbox):
@@ -117,7 +117,7 @@ def test_multiple_accounts(fresh_counter, sandbox):
     fresh_counter.call("increment").as_transaction(user2)
 
     # Check final count
-    count = fresh_counter.call("get_count").as_view()
+    count = fresh_counter.call("get_count").as_view().text
     assert int(count) == 3
 
 
@@ -131,7 +131,7 @@ def test_reset(fresh_counter, localnet_bob_account):
     fresh_counter.call("reset", value=5).as_transaction(localnet_bob_account)
 
     # Verify reset worked
-    count = fresh_counter.call("get_count").as_view()
+    count = fresh_counter.call("get_count").as_view().text
     assert int(count) == 5
 
 
@@ -156,12 +156,12 @@ def test_state_persistence(sandbox, counter_wasm):
     contract.call("increment").as_transaction(account)
 
     # Verify count is now 12
-    count = contract.call("get_count").as_view()
+    count = contract.call("get_count").as_view().text
     assert int(count) == 12
 
     # Reset to initial state
     sandbox.reset_state(initial_state)
 
     # Verify count is back to 10
-    count = contract.call("get_count").as_view()
+    count = contract.call("get_count").as_view().text
     assert int(count) == 10

--- a/src/near_pytest/models.py
+++ b/src/near_pytest/models.py
@@ -25,7 +25,7 @@ class ContractResponse:
 
     @classmethod
     def from_result(
-        cls, result: Union[str, TransactionResult], log_prefix: str = "Contract"
+        cls, result: Union[str, int, TransactionResult], log_prefix: str = "Contract"
     ) -> "ContractResponse":
         """Create a ContractResponse from a raw result.
 
@@ -39,7 +39,7 @@ class ContractResponse:
         Raises:
             ContractCallError: If the contract call failed
         """
-        if isinstance(result, str):
+        if isinstance(result, str) or isinstance(result, int):
             return cls(result)
 
         # Process logs

--- a/src/near_pytest/models.py
+++ b/src/near_pytest/models.py
@@ -322,4 +322,5 @@ class Contract:
         Returns:
             The result of the view method call
         """
-        return self.client.view_function(self.account_id, method_name, args)
+        result = self.client.view_function(self.account_id, method_name, args)
+        return ContractResponse.from_result(result)

--- a/src/near_pytest/models.py
+++ b/src/near_pytest/models.py
@@ -1,12 +1,101 @@
-from typing import Dict, Any, Optional, TYPE_CHECKING, List, Union, Tuple, cast
+from typing import Dict, Any, Optional, TYPE_CHECKING, List, Union, Tuple, TypeVar
 from py_near.constants import DEFAULT_ATTACHED_GAS
 from py_near.models import TransactionResult
 from .utils.logger import logger
 import base64
+import json
 
 # Prevent circular imports while still enabling type checking
 if TYPE_CHECKING:
     from .client import NearClient
+
+T = TypeVar("T")
+
+
+class ContractResponse:
+    """Wrapper for contract call responses that adds additional functionality like JSON parsing.
+
+    This class encapsulates the response processing logic and provides a clean API for
+    interacting with contract call results.
+
+    Attributes:
+        value: The decoded string value from the contract call
+        transaction_result: The full transaction result if available
+    """
+
+    @classmethod
+    def from_result(
+        cls, result: Union[str, TransactionResult], log_prefix: str = "Contract"
+    ) -> "ContractResponse":
+        """Create a ContractResponse from a raw result.
+
+        Args:
+            result: Either a string result or a TransactionResult
+            log_prefix: Prefix for log messages
+
+        Returns:
+            A new ContractResponse instance
+
+        Raises:
+            ContractCallError: If the contract call failed
+        """
+        if isinstance(result, str):
+            return cls(result)
+
+        # Process logs
+        logs: List[str] = []
+        for ro in result.receipt_outcome:
+            logs.extend(ro.logs)
+        if logs:
+            logger.info(f"{log_prefix} Logs:")
+            logger.info("\n".join(logs))
+
+        status = result.status
+        if "SuccessValue" in status:
+            parsed_value = base64.b64decode(status["SuccessValue"]).decode("utf-8")
+            return cls(parsed_value, result)
+        else:
+            raise ContractCallError("Error calling function", result)
+
+    def __init__(
+        self, value: str, transaction_result: Optional[TransactionResult] = None
+    ):
+        """Initialize a ContractResponse.
+
+        Args:
+            value: The string value from the contract call
+            transaction_result: The full transaction result if available
+        """
+        self.value = value
+        self.transaction_result = transaction_result
+
+    def __str__(self) -> str:
+        """String representation of the response.
+
+        Returns:
+            The string value from the contract call
+        """
+        return self.value
+
+    @property
+    def text(self) -> str:
+        """Get the response content as a string.
+
+        Returns:
+            The string value from the contract call
+        """
+        return self.value
+
+    def json(self) -> Any:
+        """Parse the response value as JSON.
+
+        Returns:
+            The parsed JSON object.
+
+        Raises:
+            json.JSONDecodeError: If the response is not valid JSON.
+        """
+        return json.loads(self.value)
 
 
 class ContractCallError(Exception):
@@ -63,8 +152,6 @@ class ContractCallError(Exception):
             if receipt_errors:
                 error_info["receipt_errors"] = receipt_errors
 
-        import json
-
         return json.dumps(error_info, indent=2, default=str)
 
 
@@ -91,7 +178,7 @@ class Account:
         amount: int = 0,
         gas: Optional[int] = DEFAULT_ATTACHED_GAS,
         return_full_result: bool = False,
-    ) -> Union[str, Tuple[str, TransactionResult]]:
+    ) -> Union[ContractResponse, Tuple[ContractResponse, Optional[TransactionResult]]]:
         """Call a contract method.
 
         Args:
@@ -103,7 +190,7 @@ class Account:
             return_full_result: Whether to return both the parsed value and full result
 
         Returns:
-            Either the parsed result as a string, or a tuple of (parsed_result, full_result)
+            Either the parsed result as a ContractResponse, or a tuple of (parsed_result, full_result)
 
         Raises:
             ContractCallError: If the contract call fails
@@ -112,7 +199,10 @@ class Account:
             self.account_id, contract_id, method_name, args, amount, gas
         )
 
-        return self._process_call_result(result, return_full_result)
+        response = ContractResponse.from_result(result, log_prefix="Account")
+        return (
+            (response, response.transaction_result) if return_full_result else response
+        )
 
     def view_contract(
         self, contract_id: str, method_name: str, args: Optional[Dict[str, Any]] = None
@@ -140,43 +230,6 @@ class Account:
         """
         return self.client.deploy_contract(self.account_id, wasm_file)
 
-    def _process_call_result(
-        self, result: Union[str, TransactionResult], return_full_result: bool = False
-    ) -> Union[str, Tuple[str, TransactionResult]]:
-        """Process the result of a contract call.
-
-        Args:
-            result: The result from the client call
-            return_full_result: Whether to return both parsed value and full result
-
-        Returns:
-            Either the parsed result as a string, or a tuple of (parsed_result, full_result)
-
-        Raises:
-            ContractCallError: If the contract call failed
-        """
-        if isinstance(result, str):
-            return (
-                (result, cast(TransactionResult, None))
-                if return_full_result
-                else result
-            )
-
-        # Print contract logs
-        logs: List[str] = []
-        for ro in result.receipt_outcome:
-            logs.extend(ro.logs)
-        if logs:
-            logger.info("Contract Logs:")
-            logger.info("\n".join(logs))
-
-        status = result.status
-        if "SuccessValue" in status:
-            parsed_value = base64.b64decode(status["SuccessValue"]).decode("utf-8")
-            return (parsed_value, result) if return_full_result else parsed_value
-        else:
-            raise ContractCallError("Error calling function", result)
-
 
 class Contract:
     """A simplified contract model for interacting with NEAR smart contracts.
@@ -200,7 +253,7 @@ class Contract:
         amount: int = 0,
         gas: Optional[int] = DEFAULT_ATTACHED_GAS,
         return_full_result: bool = False,
-    ) -> Union[str, Tuple[str, TransactionResult]]:
+    ) -> Union[ContractResponse, Tuple[ContractResponse, Optional[TransactionResult]]]:
         """Call the contract as itself.
 
         Args:
@@ -211,7 +264,7 @@ class Contract:
             return_full_result: Whether to return both the parsed value and full result
 
         Returns:
-            Either the parsed result as a string, or a tuple of (parsed_result, full_result)
+            Either the parsed result as a ContractResponse, or a tuple of (parsed_result, full_result)
 
         Raises:
             ContractCallError: If the contract call fails
@@ -220,7 +273,10 @@ class Contract:
             self.account_id, self.account_id, method_name, args, amount, gas
         )
 
-        return self._process_call_result(result, return_full_result)
+        response = ContractResponse.from_result(result)
+        return (
+            (response, response.transaction_result) if return_full_result else response
+        )
 
     def call_as(
         self,
@@ -230,7 +286,7 @@ class Contract:
         amount: int = 0,
         gas: Optional[int] = DEFAULT_ATTACHED_GAS,
         return_full_result: bool = False,
-    ) -> Union[str, Tuple[str, TransactionResult]]:
+    ) -> Union[ContractResponse, Tuple[ContractResponse, Optional[TransactionResult]]]:
         """Call the contract as a different account.
 
         Args:
@@ -242,7 +298,7 @@ class Contract:
             return_full_result: Whether to return both the parsed value and full result
 
         Returns:
-            Either the parsed result as a string, or a tuple of (parsed_result, full_result)
+            Either the parsed result as a ContractResponse, or a tuple of (parsed_result, full_result)
 
         Raises:
             ContractCallError: If the contract call fails
@@ -251,7 +307,10 @@ class Contract:
             account.account_id, self.account_id, method_name, args, amount, gas
         )
 
-        return self._process_call_result(result, return_full_result)
+        response = ContractResponse.from_result(result)
+        return (
+            (response, response.transaction_result) if return_full_result else response
+        )
 
     def view(self, method_name: str, args: Optional[Dict[str, Any]] = None) -> Any:
         """Call a view method on the contract.
@@ -264,36 +323,3 @@ class Contract:
             The result of the view method call
         """
         return self.client.view_function(self.account_id, method_name, args)
-
-    def _process_call_result(
-        self, result: Union[str, TransactionResult], return_full_result: bool = False
-    ) -> Union[str, Tuple[str, TransactionResult]]:
-        """Process the result of a contract call.
-
-        Args:
-            result: The result from the client call
-            return_full_result: Whether to return both parsed value and full result
-
-        Returns:
-            Either the parsed result as a string, or a tuple of (parsed_result, full_result)
-
-        Raises:
-            ContractCallError: If the contract call failed
-        """
-        if isinstance(result, str):
-            return (
-                (result, cast(TransactionResult, None))
-                if return_full_result
-                else result
-            )
-
-        # Print contract logs
-        logger.info("Contract Logs:")
-        logger.info("\n".join(result.logs))
-
-        status = result.status
-        if "SuccessValue" in status:
-            parsed_value = base64.b64decode(status["SuccessValue"]).decode("utf-8")
-            return (parsed_value, result) if return_full_result else parsed_value
-        else:
-            raise ContractCallError("Error calling function", result)

--- a/src/near_pytest/models.py
+++ b/src/near_pytest/models.py
@@ -58,7 +58,9 @@ class ContractResponse:
             raise ContractCallError("Error calling function", result)
 
     def __init__(
-        self, value: str, transaction_result: Optional[TransactionResult] = None
+        self,
+        value: Union[str, int],
+        transaction_result: Optional[TransactionResult] = None,
     ):
         """Initialize a ContractResponse.
 
@@ -75,7 +77,7 @@ class ContractResponse:
         Returns:
             The string value from the contract call
         """
-        return self.value
+        return str(self.value)
 
     @property
     def text(self) -> str:
@@ -84,7 +86,7 @@ class ContractResponse:
         Returns:
             The string value from the contract call
         """
-        return self.value
+        return str(self.value)
 
     def json(self) -> Any:
         """Parse the response value as JSON.
@@ -95,7 +97,7 @@ class ContractResponse:
         Raises:
             json.JSONDecodeError: If the response is not valid JSON.
         """
-        return json.loads(self.value)
+        return json.loads(str(self.value))
 
 
 class ContractCallError(Exception):
@@ -312,7 +314,9 @@ class Contract:
             (response, response.transaction_result) if return_full_result else response
         )
 
-    def view(self, method_name: str, args: Optional[Dict[str, Any]] = None) -> Any:
+    def view(
+        self, method_name: str, args: Optional[Dict[str, Any]] = None
+    ) -> ContractResponse:
         """Call a view method on the contract.
 
         Args:

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "near-pytest"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Overview
This PR introduces a `ContractResponse` class that wraps contract call responses with a familiar API similar to Python's `requests` library. This makes handling contract responses more intuitive, especially when dealing with JSON data.

## Changes

### Added
- New `ContractResponse` class that wraps the string value returned from contract calls
- `.json()` method to parse responses as JSON (similar to `requests.Response.json()`)
- `.text` property to access the raw text response (similar to `requests.Response.text`)

### Refactored
- Extracted duplicate `_process_call_result` logic into the `ContractResponse` class
- Updated return type annotations to properly handle optional transaction results

### Documentation
- Updated README with examples showing the new response handling API
- Added new section in README explaining the `ContractResponse` class

## Usage Examples

### JSON response handling
```python
# Call a method that returns JSON
response = contract.call("get_user_data", {"user_id": "alice"})

# Parse the response
user_data = response.json()
assert user_data["name"] == "Alice"
```

### Accessing raw text
```python
response = contract.call("get_message")
assert response.text == "Hello, NEAR!"
```

## Backwards Compatibility
This change maintains full backwards compatibility with existing code through the `__str__` method. Any code that treats the response as a string will continue to work without modification:

```python
# Old code still works
result = contract.call("increment", {})
assert int(result) == 1  # Implicitly converts to string
```